### PR TITLE
Packaging for medieval distros

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,10 @@
   outputs = { self, nixpkgs }: let
     system = "x86_64-linux";
     pkgs = nixpkgs.legacyPackages.${system};
-
+    packaging = import ./nix/packaging {
+      inherit pkgs;
+      inherit (self.packages.${system}) zedless;
+    };
   in {
     devShells.${system}.default = pkgs.mkShell {
       nativeBuildInputs = with pkgs; [
@@ -23,6 +26,7 @@
         source = self.packages.${system}.zedless-source;
       };
       default = self.packages.${system}.zedless;
+      inherit (packaging) rpm;
     };
   };
 }

--- a/nix/packaging/default.nix
+++ b/nix/packaging/default.nix
@@ -1,0 +1,72 @@
+{ pkgs, zedless }:
+
+let
+  zedless-fhs = pkgs.runCommand "zedless-fhs-${zedless.version}" { } ''
+    cp -r --no-preserve=mode ${zedless} $out
+    chmod +x $out/bin/* $out/libexec/*
+    patchelf $out/bin/zedless $out/libexec/zedless-editor --set-interpreter /lib64/ld-linux-x86-64.so.2 --remove-rpath
+  '';
+
+  libwebrtc-fhs = pkgs.runCommand "libwebrtc-fhs" { } ''
+    cp -r --no-preserve=mode ${pkgs.livekit-libwebrtc.out} $out
+    patchelf $out/lib/lib*.so --remove-rpath
+  '';
+
+  nfpmConfig = pkgs.writeText "nfpm.json" (builtins.toJSON {
+    name = zedless.pname;
+    inherit (zedless) version;
+    arch = "amd64";
+    platform = "linux";
+    homepage = "https://zedless.org";
+    description = "Zedless Editor";
+    license = zedless.meta.license.spdxId;
+    contents = [
+      {
+        type = "tree";
+        src = zedless-fhs;
+        dst = "/usr";
+      }
+      {
+        type = "tree";
+        src = libwebrtc-fhs;
+        dst = "/usr";
+      }
+    ];
+    rpm.compression = "zstd";
+  });
+in
+
+{
+  rpm = pkgs.runCommand "zedless-rpm-${zedless.version}" {
+    nativeBuildInputs = [
+      pkgs.elfdeps
+      pkgs.nfpm
+      pkgs.jq
+    ];
+  } ''
+    mkdir $out
+    (
+        (
+            elfdeps --requires ${zedless-fhs}/bin/zedless
+            elfdeps --requires ${zedless-fhs}/libexec/zedless-editor
+            elfdeps --requires ${libwebrtc-fhs}/lib/libwebrtc.so
+            elfdeps --requires ${libwebrtc-fhs}/lib/libthird_party_boringssl.so
+        ) | sort -u
+        echo :
+        (
+            elfdeps --provides ${libwebrtc-fhs}/lib/libwebrtc.so
+            elfdeps --provides ${libwebrtc-fhs}/lib/libthird_party_boringssl.so
+        ) | sort -u
+    ) | jq --raw-input --slurp --slurpfile config ${nfpmConfig} '
+        $config[0] * {
+            overrides: {
+                rpm: {
+                    depends: split(":")[0] | split("\n") | map(select(length > 0)),
+                    provides: split(":")[1] | split("\n") | map(select(length > 0))
+                }
+            }
+        }
+    ' > nfpm.json
+    nfpm package --config nfpm.json --target $out/${zedless.name}.rpm --packager rpm
+  '';
+}


### PR DESCRIPTION
Takes the package built by Nix, removes the RPATH, fixes the interpreter, and shoves the result into a package. Currently only provides RPM, but I might add other formats that nfpm supports as well.

Currently also includes `libwebrtc.so` because Fedora doesn't provide it in the regular repos.