### PR TITLE
Add a -c flag to commit after each phase

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -68,21 +68,27 @@ def runRules(rules):
         configFile.close()
         # HACK: some of our rules can be applied multiple times,
         # so run ast-grep until no more changes are applied
-        while True:
-            r = run([
-                "ast-grep", "scan", "--update-all",
-                "--config", configFile.name,
-                "--rule", "/dev/stdin",
-                "--color", "never",
-                "."
-            ], input="\n---\n".join([dumps(r) for r in rules]).encode(), capture_output=True)
-            output = r.stderr.decode()
-            if r.returncode != 0:
-                print(output)
-                exit(r.returncode)
-            if not (output.startswith("Applied ") and output.endswith(" changes\n")):
-                break
-            print(output.strip())
+        import sys
+        import tempfile
+        rules = "\n---\n".join([dumps(r) for r in rules]).encode()
+        with tempfile.NamedTemporaryFile(delete=False,delete_on_close=False) as ftmp:
+            ftmp.write(rules)
+            ftmp.flush(); ftmp.seek(0); ftmp.close()
+            while True:
+                r = run([
+                    "ast-grep", "scan", "--update-all",
+                    "--config", configFile.name,
+                    "--rule", ftmp.name,
+                    "--color", "never",
+                    "."
+                ], capture_output=True)
+                output = r.stderr.decode()
+                if r.returncode != 0:
+                    print(output)
+                    exit(r.returncode)
+                if not (output.startswith("Applied ") and output.endswith(" changes\n")):
+                    break
+                print(output.strip())
 
 def deletePatterns(target, language, patterns, selector=None):
     rule = {

--- a/patch.py
+++ b/patch.py
@@ -590,7 +590,7 @@ with chdir(args.src):
             run(["git","commit","-m","✗ 1.2 Removed Deleted Crates from Cargo"])
             runRules(rules)
             run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-            run(["git","commit","-m","✗ 1.3 Removed references to Deleted Crates from source files"])
+            run(["git","commit","-m","rules: 1.3 Removed references to Deleted Crates from source files"])
             rules = []
 
     for (crate, mod) in CONFIG.bannedModules:
@@ -675,22 +675,26 @@ with chdir(args.src):
         tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
         for tgt in tgt_mod:
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
-        if args.commit:
+        if args.commit and args.verbose:
             run(["git","add",".","-u"])
-            run(["git","commit","-m","✗ 2a Deleted module files"])
+            run(["git","commit","-m",f"✗ 2.1 Deleted mod {mod} @ {crate}"])
             runRules(rules)
             run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-            run(["git","commit","-m","✗ 2c Removed references to Deleted modules from source files"])
+            run(["git","commit","-m",f"rules: 2.2 Removed refs to Deleted mod {mod} @ {crate} from source files"])
             rules = []
+    if args.commit and not args.verbose:
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","✗ 2.1 Deleted module files"])
+        runRules(rules)
+        run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+        run(["git","commit","-m","rules: 2.2 Removed references to Deleted modules from source files"])
+        rules = []
 
     for provider in CONFIG.bannedLanguageModelProviders:
         tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
         tgt = tgt_src / f"{provider.module}.rs"
         print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
         shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
-        if args.commit:
-            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
-            run(["git","commit","-m","✗ 3a Deleted language model providers"])
         rules.extend(deletePatterns("crates/language_models/", "rust", [
             f"pub mod {provider.module};",
             f"use crate::provider::{provider.module}::$_;",
@@ -722,11 +726,13 @@ with chdir(args.src):
         ]))
         rules.extend(removeFieldsInDeclarations(provider.param, target="crates/language_models/"))
         rules.extend(removeExprArguments(provider.param, target="crates/language_models/"))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-            run(["git","commit","-m","✗ 3c Removed references to deleted Language module providers from source files"])
-            rules = []
+    if args.commit:
+        run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+        run(["git","commit","-m","✗ 3.1 Deleted language model providers"])
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 3.2 Removed references to deleted Language module providers from source files"])
+        rules = []
 
     rules.extend(deleteDeclarations("struct_item", "OpenAiLanguageModelProvider", target="crates/language_models/"))
     rules.extend(deleteDeclarations("impl_item", "OpenAiLanguageModelProvider", identifierField="type", target="crates/language_models/"))
@@ -778,14 +784,24 @@ with chdir(args.src):
             }
         }
     ))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 4.1 Remove Language models"])
+        rules = []
 
     for (crate, cfg) in CONFIG.perCrate.items():
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("impl_item", f"{crate}::{enum}", identifierField="type"))
-    if args.commit:
+        if args.commit and args.verbose:
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m",f"rules: 4.2 Remove per Crate items @ {crate} from source files"])
+            rules = []
+    if args.commit and not args.verbose:
         runRules(rules)
         run(["git","add",".","-u"])
-        run(["git","commit","-m","rules: 4.1 Remove Language model providers and Enums"])
+        run(["git","commit","-m","rules: 4.2 Remove per Crate items"])
         rules = []
 
     for (target, cfg) in CONFIG.perDirectory.items():
@@ -882,11 +898,6 @@ with chdir(args.src):
                     }
                 ]
             }))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.2 Remove Functions"])
-            rules = []
 
         for struct in cfg.bannedStructs:
             rules.extend(deleteDeclarations("struct_item", struct, target=target))
@@ -895,11 +906,6 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"{struct}::register($$$);",
             ]))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.3 Remove Structs"])
-            rules = []
 
         for arg in cfg.bannedArguments:
             rules.extend(removeFieldsInDeclarations(arg, target=target))
@@ -923,11 +929,6 @@ with chdir(args.src):
                 f"self.{arg}.is_empty()",
                 f"self.{arg}.is_none()",
             ], "true", deleteStatements=False, target=target))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.4 Remove Aarguments"])
-            rules = []
 
         for local in cfg.bannedLocals:
             rules.extend(deleteDeclarations("let_declaration", local, "pattern", target=target))
@@ -1012,11 +1013,6 @@ with chdir(args.src):
                 "kind": "call_expression",
                 "pattern": f"{local}.as_ref().map($$$).or($$$OR).unwrap_or_default()"
             }, "($$$OR).unwrap_or_default()"))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.5 Remove Locals"])
-            rules = []
 
         for action in cfg.bannedActions:
             rules.extend(removeMethodCall("register_action", {
@@ -1081,11 +1077,6 @@ with chdir(args.src):
                     })
                 }
             ]))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.6 Remove Actions"])
-            rules = []
 
         for variant in cfg.bannedEnumVariants:
             scopedIdentifier = {
@@ -1144,11 +1135,6 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"$_.push($_::{variant});",
             ], "expression_statement"))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.7 Remove Enum variants"])
-            rules = []
 
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("enum_item", enum, target=target))
@@ -1168,32 +1154,27 @@ with chdir(args.src):
                     }
                 }
             }))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.8 Remove Enums"])
-            rules = []
 
         for function in cfg.disabledFunctions:
             rules.extend(disableAnyhowFunction(target, function))
             rules.extend(disableOptionFunction(target, function))
             rules.extend(disableBoolFunction(target, function))
             rules.extend(disableFutureAnyhowFunction(target, function))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.9 Remove Functions"])
-            rules = []
 
         for (original, replacement) in cfg.stringReplacements:
             rules.extend(mkRule(target, "rust", {
                 "pattern": f"\"{original}\""
             }, f"\"{replacement}\""))
-        if args.commit:
+        if args.commit and args.verbose:
             runRules(rules)
             run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.10 Removed strings"])
+            run(["git","commit","-m",f"rules: 4.3 Remove per Directory items @{target}"])
             rules = []
+    if args.commit and not args.verbose:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 4.3 Remove per Directory items"])
+        rules = []
 
     bannedMenuItemArgumentsSelector = {
         "kind": "token_tree",

--- a/patch.py
+++ b/patch.py
@@ -478,6 +478,8 @@ def nullifyIfStatement(target, conditionPattern: str | list[str], selectElse=Tru
 from pathlib      import Path
 args = parser.parse_args()
 import shutil
+import os
+dir_main = os.path.dirname(os.path.realpath(__file__))
 with chdir(args.src):
     rules = []
 
@@ -1302,6 +1304,8 @@ with chdir(args.src):
 
     runRules(rules)
 
-    run([
-        "cp", "-r", "../overlay/.", "."
-    ]).check_returncode()
+    src = Path(dir_main) / 'overlay' / '.'
+    tgt = Path(args.src)
+    if args.verbose:
+        print(f"  {src}\n →{tgt}")
+    shutil.copytree(src,tgt,dirs_exist_ok=True)

--- a/patch.py
+++ b/patch.py
@@ -19,6 +19,7 @@ parser = argparse.ArgumentParser(
     epilog     ='')
 parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
 parser.add_argument('-v','--verbose',action='store_true',help="Print more info when running")
+parser.add_argument('-c','--commit',action='store_true',help="Commit modified/deleted after each stage")
 
 @contextmanager
 def editTomlDocument(file):
@@ -52,6 +53,10 @@ def mkRule(target, language, rule, fix):
     }
 
 def runRules(rules):
+    if not rules:
+        if args.verbose:
+            print('No rules to run!')
+        return
     astGrepConfig = {
         "languageInjections": [
             {
@@ -540,6 +545,9 @@ with chdir(args.src):
             tgt = Path(args.src) / 'crates' / crate
             print(f"del crate: {crate}\t@ {tgt}")
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
+        if args.commit:
+            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+            run(["git","commit","-m","✗ 1.2 Deleted Crates"])
 
         with editTomlDocument("Cargo.toml") as (data, write):
             data["workspace"]["members"] = list(filter(
@@ -577,6 +585,13 @@ with chdir(args.src):
                         if bin["name"] == "zed":
                             data["bin"][i]["name"] = "zedless"
                 write(data)
+        if args.commit:
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 1.2 Removed Deleted Crates from Cargo"])
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 1.3 Removed references to Deleted Crates from source files"])
+            rules = []
 
     for (crate, mod) in CONFIG.bannedModules:
         tgt_src = Path(args.src) / 'crates' / crate / 'src'
@@ -660,12 +675,22 @@ with chdir(args.src):
         tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
         for tgt in tgt_mod:
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
+        if args.commit:
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","✗ 2a Deleted module files"])
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 2c Removed references to Deleted modules from source files"])
+            rules = []
 
     for provider in CONFIG.bannedLanguageModelProviders:
         tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
         tgt = tgt_src / f"{provider.module}.rs"
         print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
         shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
+        if args.commit:
+            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+            run(["git","commit","-m","✗ 3a Deleted language model providers"])
         rules.extend(deletePatterns("crates/language_models/", "rust", [
             f"pub mod {provider.module};",
             f"use crate::provider::{provider.module}::$_;",
@@ -697,6 +722,11 @@ with chdir(args.src):
         ]))
         rules.extend(removeFieldsInDeclarations(provider.param, target="crates/language_models/"))
         rules.extend(removeExprArguments(provider.param, target="crates/language_models/"))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 3c Removed references to deleted Language module providers from source files"])
+            rules = []
 
     rules.extend(deleteDeclarations("struct_item", "OpenAiLanguageModelProvider", target="crates/language_models/"))
     rules.extend(deleteDeclarations("impl_item", "OpenAiLanguageModelProvider", identifierField="type", target="crates/language_models/"))
@@ -752,6 +782,11 @@ with chdir(args.src):
     for (crate, cfg) in CONFIG.perCrate.items():
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("impl_item", f"{crate}::{enum}", identifierField="type"))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 4.1 Remove Language model providers and Enums"])
+        rules = []
 
     for (target, cfg) in CONFIG.perDirectory.items():
         for function in cfg.bannedFunctions:
@@ -847,6 +882,11 @@ with chdir(args.src):
                     }
                 ]
             }))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.2 Remove Functions"])
+            rules = []
 
         for struct in cfg.bannedStructs:
             rules.extend(deleteDeclarations("struct_item", struct, target=target))
@@ -855,6 +895,11 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"{struct}::register($$$);",
             ]))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.3 Remove Structs"])
+            rules = []
 
         for arg in cfg.bannedArguments:
             rules.extend(removeFieldsInDeclarations(arg, target=target))
@@ -878,6 +923,11 @@ with chdir(args.src):
                 f"self.{arg}.is_empty()",
                 f"self.{arg}.is_none()",
             ], "true", deleteStatements=False, target=target))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.4 Remove Aarguments"])
+            rules = []
 
         for local in cfg.bannedLocals:
             rules.extend(deleteDeclarations("let_declaration", local, "pattern", target=target))
@@ -962,6 +1012,11 @@ with chdir(args.src):
                 "kind": "call_expression",
                 "pattern": f"{local}.as_ref().map($$$).or($$$OR).unwrap_or_default()"
             }, "($$$OR).unwrap_or_default()"))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.5 Remove Locals"])
+            rules = []
 
         for action in cfg.bannedActions:
             rules.extend(removeMethodCall("register_action", {
@@ -1026,6 +1081,11 @@ with chdir(args.src):
                     })
                 }
             ]))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.6 Remove Actions"])
+            rules = []
 
         for variant in cfg.bannedEnumVariants:
             scopedIdentifier = {
@@ -1084,6 +1144,11 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"$_.push($_::{variant});",
             ], "expression_statement"))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.7 Remove Enum variants"])
+            rules = []
 
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("enum_item", enum, target=target))
@@ -1103,17 +1168,32 @@ with chdir(args.src):
                     }
                 }
             }))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.8 Remove Enums"])
+            rules = []
 
         for function in cfg.disabledFunctions:
             rules.extend(disableAnyhowFunction(target, function))
             rules.extend(disableOptionFunction(target, function))
             rules.extend(disableBoolFunction(target, function))
             rules.extend(disableFutureAnyhowFunction(target, function))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.9 Remove Functions"])
+            rules = []
 
         for (original, replacement) in cfg.stringReplacements:
             rules.extend(mkRule(target, "rust", {
                 "pattern": f"\"{original}\""
             }, f"\"{replacement}\""))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.10 Removed strings"])
+            rules = []
 
     bannedMenuItemArgumentsSelector = {
         "kind": "token_tree",
@@ -1193,6 +1273,11 @@ with chdir(args.src):
                     }
                 }
             }, f"\"{actionName}\""))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 5 Remove menu actions/menu items"])
+        rules = []
 
     rules.extend(mkRule("crates/zed/src/zed/app_menus.rs", "rust", { "pattern": "\"Zed\"" }, "\"Zedless\""))
 
@@ -1234,6 +1319,11 @@ with chdir(args.src):
     ]))
 
     rules.extend(removeMethodCall("child", match.rust.functionCall("render_telemetry_section"), target="crates/onboarding/"))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 6 Remove settings content/telemetry/misc."])
+        rules = []
 
     # The `None` here is an Option<ActionLogTelemetry>, which was removed
     rules.extend(editAstAdvanced("crates/agent_ui/", "rust", [
@@ -1264,6 +1354,11 @@ with chdir(args.src):
             "stopBy": "end"
         }
     }, "{ None }"))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 7 Remove agent/remote/misc."])
+        rules = []
 
     # Cleanup
     rules.extend(deletePatterns("crates/", "rust", [
@@ -1309,6 +1404,11 @@ with chdir(args.src):
     }, ""))
 
     runRules(rules)
+
+    if args.commit:
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 8 Cleanup"])
+        rules = []
 
     src = Path(dir_main) / 'overlay' / '.'
     tgt = Path(args.src)

--- a/patch.py
+++ b/patch.py
@@ -494,6 +494,10 @@ dir_main = os.path.dirname(os.path.realpath(__file__))
 with chdir(args.src):
     rules = []
 
+    if args.commit:
+        run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+        run(["git","commit","-m",f"0: Modificaitons before Zedless patches"])
+
     cratesToDelete = []
     for crate in CONFIG.bannedCrates:
         if exists(f"crates/{crate}"):

--- a/patch.py
+++ b/patch.py
@@ -12,6 +12,13 @@ import toml
 import match
 import match.rust
 
+import argparse
+parser = argparse.ArgumentParser(
+    prog       ='Zedless Patch',
+    description='Patches Zed with focus on privacy and being local-first',
+    epilog     ='')
+parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
+
 @contextmanager
 def editTomlDocument(file):
     def callback(v):
@@ -467,8 +474,8 @@ def nullifyIfStatement(target, conditionPattern: str | list[str], selectElse=Tru
             for pattern in conditionPattern
         ])
 
-
-with chdir("source"):
+args = parser.parse_args()
+with chdir(args.src):
     rules = []
 
     cratesToDelete = []

--- a/patch.py
+++ b/patch.py
@@ -474,7 +474,9 @@ def nullifyIfStatement(target, conditionPattern: str | list[str], selectElse=Tru
             for pattern in conditionPattern
         ])
 
+from pathlib      import Path
 args = parser.parse_args()
+import shutil
 with chdir(args.src):
     rules = []
 
@@ -526,8 +528,9 @@ with chdir(args.src):
 
     if len(cratesToDelete) > 0:
         for crate in cratesToDelete:
-            print("delete crate:", crate)
-            run(["rm", "-rf", f"crates/{crate}/"])
+            tgt = Path(args.src) / 'crates' / crate
+            print(f"del crate: {crate}\t@ {tgt}")
+            shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
 
         with editTomlDocument("Cargo.toml") as (data, write):
             data["workspace"]["members"] = list(filter(
@@ -567,7 +570,8 @@ with chdir(args.src):
                 write(data)
 
     for (crate, mod) in CONFIG.bannedModules:
-        print("delete module:", crate, mod)
+        tgt_src = Path(args.src) / 'crates' / crate / 'src'
+        print("del mod:", crate, mod, f"\t@ {tgt_src}")
         rules.extend(deletePatterns(f"crates/{crate}/", "rust", [
             f"mod {mod};",
             f"pub mod {mod};",
@@ -642,11 +646,17 @@ with chdir(args.src):
                 }
             }
         }))
-        run(["rm", "-f", f"crates/{crate}/src/{mod}.rs"] + glob(f"crates/{crate}/src/*/{mod}.rs"))
+        tgt_src = Path(args.src) / 'crates' / crate / 'src'
+        tgt_mod =  [    tgt_src    /   f"{mod}.rs"]
+        tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
+        for tgt in tgt_mod:
+            shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
 
     for provider in CONFIG.bannedLanguageModelProviders:
-        print("delete language model provider:", provider.structPrefix)
-        run(["rm", "-f", f"crates/language_models/src/provider/{provider.module}.rs"])
+        tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
+        tgt = tgt_src / f"{provider.module}.rs"
+        print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
+        shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
         rules.extend(deletePatterns("crates/language_models/", "rust", [
             f"pub mod {provider.module};",
             f"use crate::provider::{provider.module}::$_;",

--- a/patch.py
+++ b/patch.py
@@ -18,6 +18,7 @@ parser = argparse.ArgumentParser(
     description='Patches Zed with focus on privacy and being local-first',
     epilog     ='')
 parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
+parser.add_argument('-v','--verbose',action='store_true',help="Print more info when running")
 
 @contextmanager
 def editTomlDocument(file):


### PR DESCRIPTION
(stacked on top of https://github.com/zedless-editor/zedless/pull/18)

Since it's a challenge to review the full set of changes this script performs, I've added a flag that adds a commit after each batch of those (delete crates, remove them from manifests, remove modules, etc.)

With -v the commits are added on a per-item basis, otherwise for the whole group (per crate/dir)

Only deleted/modified files are commited, so should only work in an existing repo, not when simply downloading source code to the default 'source' (the script doesn't plan to add new files, do it?)
Existing changes are commited before the patches are applied
