### PR TITLE
Remove external crates from manifests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ All the required tools are available in the `devShell`, so if you're using Nix, 
 The following tools are required to execute the patch script:
 
 - Python
-- The [`toml`](https://pypi.org/project/toml/) Python package
+- The [`tomlkit`](https://pypi.org/project/tomlkit/) Python package
 - [ast-grep](https://ast-grep.github.io/)
 
 ## Patching and building the project

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       nativeBuildInputs = with pkgs; [
         ast-grep
         (python3.withPackages (ps: [
-          ps.toml
+          ps.tomlkit
         ]))
       ];
     };

--- a/nix/source.nix
+++ b/nix/source.nix
@@ -21,7 +21,7 @@ stdenvNoCC.mkDerivation{
   nativeBuildInputs = [
     ast-grep
     (python3.withPackages (ps: [
-      ps.toml
+      ps.tomlkit
     ]))
   ];
 

--- a/patch.py
+++ b/patch.py
@@ -17,7 +17,7 @@ parser = argparse.ArgumentParser(
     prog       ='Zedless Patch',
     description='Patches Zed with focus on privacy and being local-first',
     epilog     ='')
-parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
+parser.add_argument('-s','--src',type=str,default="source",help="Path to Zed's source code")
 parser.add_argument('-v','--verbose',action='store_true',help="Print more info when running")
 parser.add_argument('-c','--commit',action='store_true',help="Commit modified/deleted after each stage")
 
@@ -496,7 +496,7 @@ with chdir(args.src):
 
     if args.commit:
         run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-        run(["git","commit","-m",f"0: Modificaitons before Zedless patches"])
+        run(["git","commit","-m",f"0: Modifications before Zedless patches"])
 
     cratesToDelete = []
     for crate in CONFIG.bannedCrates:
@@ -550,7 +550,7 @@ with chdir(args.src):
             print(f"del crate: {crate}\t@ {tgt}")
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
         if args.commit:
-            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
             run(["git","commit","-m","✗ 1.2 Deleted Crates"])
 
         with editTomlDocument("Cargo.toml") as (data, write):
@@ -734,7 +734,7 @@ with chdir(args.src):
         rules.extend(removeFieldsInDeclarations(provider.param, target="crates/language_models/"))
         rules.extend(removeExprArguments(provider.param, target="crates/language_models/"))
     if args.commit:
-        run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+        run(["git","add",".","-u"]) # add changed/deleted files, ignore new
         run(["git","commit","-m","✗ 3.1 Deleted language model providers"])
         runRules(rules)
         run(["git","add",".","-u"])

--- a/patch.py
+++ b/patch.py
@@ -68,21 +68,27 @@ def runRules(rules):
         configFile.close()
         # HACK: some of our rules can be applied multiple times,
         # so run ast-grep until no more changes are applied
-        while True:
-            r = run([
-                "ast-grep", "scan", "--update-all",
-                "--config", configFile.name,
-                "--rule", "/dev/stdin",
-                "--color", "never",
-                "."
-            ], input="\n---\n".join([dumps(r) for r in rules]).encode(), capture_output=True)
-            output = r.stderr.decode()
-            if r.returncode != 0:
-                print(output)
-                exit(r.returncode)
-            if not (output.startswith("Applied ") and output.endswith(" changes\n")):
-                break
-            print(output.strip())
+        import sys
+        import tempfile
+        rules = "\n---\n".join([dumps(r) for r in rules]).encode()
+        with tempfile.NamedTemporaryFile(delete=False,delete_on_close=False) as ftmp:
+            ftmp.write(rules)
+            ftmp.flush(); ftmp.seek(0); ftmp.close()
+            while True:
+                r = run([
+                    "ast-grep", "scan", "--update-all",
+                    "--config", configFile.name,
+                    "--rule", ftmp.name,
+                    "--color", "never",
+                    "."
+                ], capture_output=True)
+                output = r.stderr.decode()
+                if r.returncode != 0:
+                    print(output)
+                    exit(r.returncode)
+                if not (output.startswith("Applied ") and output.endswith(" changes\n")):
+                    break
+                print(output.strip())
 
 def deletePatterns(target, language, patterns, selector=None):
     rule = {

--- a/patch.py
+++ b/patch.py
@@ -558,8 +558,9 @@ with chdir(zed_src):
     if len(cratesToRemove) > 0:
         with editTomlDocument("Cargo.toml") as (data, write):
             arr = data["workspace"]["members"]
-            for i in range(len(arr)):
-                j = len(arr) - i - 1
+            m_cnt = len(arr)
+            for i in range(m_cnt):
+                j = m_cnt - i - 1
                 if arr[j].removeprefix("crates/") in cratesToRemove:
                     del arr[j]
             data["workspace"]["members"] = arr

--- a/patch.py
+++ b/patch.py
@@ -590,7 +590,7 @@ with chdir(args.src):
             run(["git","commit","-m","✗ 1.2 Removed Deleted Crates from Cargo"])
             runRules(rules)
             run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-            run(["git","commit","-m","✗ 1.3 Removed references to Deleted Crates from source files"])
+            run(["git","commit","-m","rules: 1.3 Removed references to Deleted Crates from source files"])
             rules = []
 
     for (crate, mod) in CONFIG.bannedModules:
@@ -675,22 +675,26 @@ with chdir(args.src):
         tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
         for tgt in tgt_mod:
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
-        if args.commit:
+        if args.commit and args.verbose:
             run(["git","add",".","-u"])
-            run(["git","commit","-m","✗ 2a Deleted module files"])
+            run(["git","commit","-m",f"✗ 2.1 Deleted mod {mod} @ {crate}"])
             runRules(rules)
             run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-            run(["git","commit","-m","✗ 2c Removed references to Deleted modules from source files"])
+            run(["git","commit","-m",f"rules: 2.2 Removed refs to Deleted mod {mod} @ {crate} from source files"])
             rules = []
+    if args.commit and not args.verbose:
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","✗ 2.1 Deleted module files"])
+        runRules(rules)
+        run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+        run(["git","commit","-m","rules: 2.2 Removed references to Deleted modules from source files"])
+        rules = []
 
     for provider in CONFIG.bannedLanguageModelProviders:
         tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
         tgt = tgt_src / f"{provider.module}.rs"
         print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
         shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
-        if args.commit:
-            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
-            run(["git","commit","-m","✗ 3a Deleted language model providers"])
         rules.extend(deletePatterns("crates/language_models/", "rust", [
             f"pub mod {provider.module};",
             f"use crate::provider::{provider.module}::$_;",
@@ -722,11 +726,13 @@ with chdir(args.src):
         ]))
         rules.extend(removeFieldsInDeclarations(provider.param, target="crates/language_models/"))
         rules.extend(removeExprArguments(provider.param, target="crates/language_models/"))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
-            run(["git","commit","-m","✗ 3c Removed references to deleted Language module providers from source files"])
-            rules = []
+    if args.commit:
+        run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+        run(["git","commit","-m","✗ 3.1 Deleted language model providers"])
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 3.2 Removed references to deleted Language module providers from source files"])
+        rules = []
 
     rules.extend(deleteDeclarations("struct_item", "OpenAiLanguageModelProvider", target="crates/language_models/"))
     rules.extend(deleteDeclarations("impl_item", "OpenAiLanguageModelProvider", identifierField="type", target="crates/language_models/"))
@@ -778,14 +784,24 @@ with chdir(args.src):
             }
         }
     ))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 4.1 Remove Language models"])
+        rules = []
 
     for (crate, cfg) in CONFIG.perCrate.items():
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("impl_item", f"{crate}::{enum}", identifierField="type"))
-    if args.commit:
+        if args.commit and args.verbose:
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m",f"rules: 4.2 Remove per Crate items @ {crate} from source files"])
+            rules = []
+    if args.commit and not args.verbose:
         runRules(rules)
         run(["git","add",".","-u"])
-        run(["git","commit","-m","rules: 4.1 Remove Language model providers and Enums"])
+        run(["git","commit","-m","rules: 4.2 Remove per Crate items"])
         rules = []
 
     for (target, cfg) in CONFIG.perDirectory.items():
@@ -882,11 +898,6 @@ with chdir(args.src):
                     }
                 ]
             }))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.2 Remove Functions"])
-            rules = []
 
         for struct in cfg.bannedStructs:
             rules.extend(deleteDeclarations("struct_item", struct, target=target))
@@ -895,11 +906,6 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"{struct}::register($$$);",
             ]))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.3 Remove Structs"])
-            rules = []
 
         for arg in cfg.bannedArguments:
             rules.extend(removeFieldsInDeclarations(arg, target=target))
@@ -923,11 +929,6 @@ with chdir(args.src):
                 f"self.{arg}.is_empty()",
                 f"self.{arg}.is_none()",
             ], "true", deleteStatements=False, target=target))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.4 Remove Aarguments"])
-            rules = []
 
         for local in cfg.bannedLocals:
             rules.extend(deleteDeclarations("let_declaration", local, "pattern", target=target))
@@ -1012,11 +1013,6 @@ with chdir(args.src):
                 "kind": "call_expression",
                 "pattern": f"{local}.as_ref().map($$$).or($$$OR).unwrap_or_default()"
             }, "($$$OR).unwrap_or_default()"))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.5 Remove Locals"])
-            rules = []
 
         for action in cfg.bannedActions:
             rules.extend(removeMethodCall("register_action", {
@@ -1081,11 +1077,6 @@ with chdir(args.src):
                     })
                 }
             ]))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.6 Remove Actions"])
-            rules = []
 
         for variant in cfg.bannedEnumVariants:
             scopedIdentifier = {
@@ -1144,11 +1135,6 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"$_.push($_::{variant});",
             ], "expression_statement"))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.7 Remove Enum variants"])
-            rules = []
 
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("enum_item", enum, target=target))
@@ -1168,32 +1154,27 @@ with chdir(args.src):
                     }
                 }
             }))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.8 Remove Enums"])
-            rules = []
 
         for function in cfg.disabledFunctions:
             rules.extend(disableAnyhowFunction(target, function))
             rules.extend(disableOptionFunction(target, function))
             rules.extend(disableBoolFunction(target, function))
             rules.extend(disableFutureAnyhowFunction(target, function))
-        if args.commit:
-            runRules(rules)
-            run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.9 Remove Functions"])
-            rules = []
 
         for (original, replacement) in cfg.stringReplacements:
             rules.extend(mkRule(target, "rust", {
                 "pattern": f"\"{original}\""
             }, f"\"{replacement}\""))
-        if args.commit:
+        if args.commit and args.verbose:
             runRules(rules)
             run(["git","add",".","-u"])
-            run(["git","commit","-m","rules: 4.10 Removed strings"])
+            run(["git","commit","-m",f"rules: 4.3 Remove per Directory items @{target}"])
             rules = []
+    if args.commit and not args.verbose:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 4.3 Remove per Directory items"])
+        rules = []
 
     bannedMenuItemArgumentsSelector = {
         "kind": "token_tree",

--- a/patch.py
+++ b/patch.py
@@ -1407,3 +1407,7 @@ with chdir(zed_src):
     if args.verbose:
         print(f"  {src}\n →{tgt}")
     shutil.copytree(src,tgt,dirs_exist_ok=True)
+
+    if args.commit:
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","9 copy icons"])

--- a/patch.py
+++ b/patch.py
@@ -7,7 +7,7 @@ from subprocess import run
 from tempfile import NamedTemporaryFile
 from config import CONFIG
 
-import toml
+import tomlkit
 
 import match
 import match.rust
@@ -25,10 +25,10 @@ parser.add_argument('-c','--commit',action='store_true',help="Commit modified/de
 def editTomlDocument(file):
     def callback(v):
         with open(file, "w") as f:
-            toml.dump(v, f)
+            tomlkit.dump(v, f)
     value = None
     with open(file, "r") as f:
-        value = toml.load(f)
+        value = tomlkit.load(f)
     if value:
         yield value, callback
 

--- a/patch.py
+++ b/patch.py
@@ -24,7 +24,7 @@ parser.add_argument('-c','--commit',action='store_true',help="Commit modified/de
 @contextmanager
 def editTomlDocument(file):
     def callback(v):
-        with open(file, "w") as f:
+        with open(file, "w", newline='') as f:
             tomlkit.dump(v, f)
     value = None
     with open(file, "r") as f:

--- a/patch.py
+++ b/patch.py
@@ -478,6 +478,8 @@ def nullifyIfStatement(target, conditionPattern: str | list[str], selectElse=Tru
 from pathlib      import Path
 args = parser.parse_args()
 import shutil
+import os
+dir_main = os.path.dirname(os.path.realpath(__file__))
 with chdir(args.src):
     rules = []
 
@@ -1302,6 +1304,8 @@ with chdir(args.src):
 
     runRules(rules)
 
-    run([
-        "cp", "-r", "../overlay/.", "."
-    ]).check_returncode()
+    src = Path(dir_main) / 'overlay' / '.'
+    tgt = Path(args.src)
+    if args.verbose:
+        print(f"  {src}\n →{tgt}")
+    shutil.copytree(src,tgt,dirs_exist_ok=True)

--- a/patch.py
+++ b/patch.py
@@ -520,6 +520,7 @@ with chdir(zed_src):
                 }
             }
         }))
+    cratesToDelete = set(cratesToDelete) # for faster 'in set' matches
 
     crateIdentifiers = [{ "pattern": crate } for crate in CONFIG.bannedCrates]
     rules.extend(mkRule("crates/", "rust", {
@@ -555,10 +556,12 @@ with chdir(zed_src):
             run(["git","commit","-m","✗ 1.2 Deleted Crates"])
 
         with editTomlDocument("Cargo.toml") as (data, write):
-            data["workspace"]["members"] = list(filter(
-                lambda m: m.removeprefix("crates/") not in cratesToDelete,
-                data["workspace"]["members"]
-            ))
+            arr = data["workspace"]["members"]
+            for i in range(len(arr)):
+                j = len(arr) - i - 1
+                if arr[j].removeprefix("crates/") in cratesToDelete:
+                    del arr[j]
+            data["workspace"]["members"] = arr
             for crate in cratesToDelete:
                 if crate in data["workspace"]["dependencies"]:
                     del data["workspace"]["dependencies"][crate]

--- a/patch.py
+++ b/patch.py
@@ -19,6 +19,7 @@ parser = argparse.ArgumentParser(
     epilog     ='')
 parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
 parser.add_argument('-v','--verbose',action='store_true',help="Print more info when running")
+parser.add_argument('-c','--commit',action='store_true',help="Commit modified/deleted after each stage")
 
 @contextmanager
 def editTomlDocument(file):
@@ -52,6 +53,10 @@ def mkRule(target, language, rule, fix):
     }
 
 def runRules(rules):
+    if not rules:
+        if args.verbose:
+            print('No rules to run!')
+        return
     astGrepConfig = {
         "languageInjections": [
             {
@@ -540,6 +545,9 @@ with chdir(args.src):
             tgt = Path(args.src) / 'crates' / crate
             print(f"del crate: {crate}\t@ {tgt}")
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
+        if args.commit:
+            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+            run(["git","commit","-m","✗ 1.2 Deleted Crates"])
 
         with editTomlDocument("Cargo.toml") as (data, write):
             data["workspace"]["members"] = list(filter(
@@ -577,6 +585,13 @@ with chdir(args.src):
                         if bin["name"] == "zed":
                             data["bin"][i]["name"] = "zedless"
                 write(data)
+        if args.commit:
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 1.2 Removed Deleted Crates from Cargo"])
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 1.3 Removed references to Deleted Crates from source files"])
+            rules = []
 
     for (crate, mod) in CONFIG.bannedModules:
         tgt_src = Path(args.src) / 'crates' / crate / 'src'
@@ -660,12 +675,22 @@ with chdir(args.src):
         tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
         for tgt in tgt_mod:
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
+        if args.commit:
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","✗ 2a Deleted module files"])
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 2c Removed references to Deleted modules from source files"])
+            rules = []
 
     for provider in CONFIG.bannedLanguageModelProviders:
         tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
         tgt = tgt_src / f"{provider.module}.rs"
         print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
         shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
+        if args.commit:
+            run(["git","add",".","-u"]) # add chagned/deleted files, ignore new
+            run(["git","commit","-m","✗ 3a Deleted language model providers"])
         rules.extend(deletePatterns("crates/language_models/", "rust", [
             f"pub mod {provider.module};",
             f"use crate::provider::{provider.module}::$_;",
@@ -697,6 +722,11 @@ with chdir(args.src):
         ]))
         rules.extend(removeFieldsInDeclarations(provider.param, target="crates/language_models/"))
         rules.extend(removeExprArguments(provider.param, target="crates/language_models/"))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+            run(["git","commit","-m","✗ 3c Removed references to deleted Language module providers from source files"])
+            rules = []
 
     rules.extend(deleteDeclarations("struct_item", "OpenAiLanguageModelProvider", target="crates/language_models/"))
     rules.extend(deleteDeclarations("impl_item", "OpenAiLanguageModelProvider", identifierField="type", target="crates/language_models/"))
@@ -752,6 +782,11 @@ with chdir(args.src):
     for (crate, cfg) in CONFIG.perCrate.items():
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("impl_item", f"{crate}::{enum}", identifierField="type"))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 4.1 Remove Language model providers and Enums"])
+        rules = []
 
     for (target, cfg) in CONFIG.perDirectory.items():
         for function in cfg.bannedFunctions:
@@ -847,6 +882,11 @@ with chdir(args.src):
                     }
                 ]
             }))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.2 Remove Functions"])
+            rules = []
 
         for struct in cfg.bannedStructs:
             rules.extend(deleteDeclarations("struct_item", struct, target=target))
@@ -855,6 +895,11 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"{struct}::register($$$);",
             ]))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.3 Remove Structs"])
+            rules = []
 
         for arg in cfg.bannedArguments:
             rules.extend(removeFieldsInDeclarations(arg, target=target))
@@ -878,6 +923,11 @@ with chdir(args.src):
                 f"self.{arg}.is_empty()",
                 f"self.{arg}.is_none()",
             ], "true", deleteStatements=False, target=target))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.4 Remove Aarguments"])
+            rules = []
 
         for local in cfg.bannedLocals:
             rules.extend(deleteDeclarations("let_declaration", local, "pattern", target=target))
@@ -962,6 +1012,11 @@ with chdir(args.src):
                 "kind": "call_expression",
                 "pattern": f"{local}.as_ref().map($$$).or($$$OR).unwrap_or_default()"
             }, "($$$OR).unwrap_or_default()"))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.5 Remove Locals"])
+            rules = []
 
         for action in cfg.bannedActions:
             rules.extend(removeMethodCall("register_action", {
@@ -1026,6 +1081,11 @@ with chdir(args.src):
                     })
                 }
             ]))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.6 Remove Actions"])
+            rules = []
 
         for variant in cfg.bannedEnumVariants:
             scopedIdentifier = {
@@ -1084,6 +1144,11 @@ with chdir(args.src):
             rules.extend(deletePatterns(target, "rust", [
                 f"$_.push($_::{variant});",
             ], "expression_statement"))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.7 Remove Enum variants"])
+            rules = []
 
         for enum in cfg.bannedEnums:
             rules.extend(deleteDeclarations("enum_item", enum, target=target))
@@ -1103,17 +1168,32 @@ with chdir(args.src):
                     }
                 }
             }))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.8 Remove Enums"])
+            rules = []
 
         for function in cfg.disabledFunctions:
             rules.extend(disableAnyhowFunction(target, function))
             rules.extend(disableOptionFunction(target, function))
             rules.extend(disableBoolFunction(target, function))
             rules.extend(disableFutureAnyhowFunction(target, function))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.9 Remove Functions"])
+            rules = []
 
         for (original, replacement) in cfg.stringReplacements:
             rules.extend(mkRule(target, "rust", {
                 "pattern": f"\"{original}\""
             }, f"\"{replacement}\""))
+        if args.commit:
+            runRules(rules)
+            run(["git","add",".","-u"])
+            run(["git","commit","-m","rules: 4.10 Removed strings"])
+            rules = []
 
     bannedMenuItemArgumentsSelector = {
         "kind": "token_tree",
@@ -1193,6 +1273,11 @@ with chdir(args.src):
                     }
                 }
             }, f"\"{actionName}\""))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 5 Remove menu actions/menu items"])
+        rules = []
 
     rules.extend(mkRule("crates/zed/src/zed/app_menus.rs", "rust", { "pattern": "\"Zed\"" }, "\"Zedless\""))
 
@@ -1234,6 +1319,11 @@ with chdir(args.src):
     ]))
 
     rules.extend(removeMethodCall("child", match.rust.functionCall("render_telemetry_section"), target="crates/onboarding/"))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 6 Remove settings content/telemetry/misc."])
+        rules = []
 
     # The `None` here is an Option<ActionLogTelemetry>, which was removed
     rules.extend(editAstAdvanced("crates/agent_ui/", "rust", [
@@ -1264,6 +1354,11 @@ with chdir(args.src):
             "stopBy": "end"
         }
     }, "{ None }"))
+    if args.commit:
+        runRules(rules)
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 7 Remove agent/remote/misc."])
+        rules = []
 
     # Cleanup
     rules.extend(deletePatterns("crates/", "rust", [
@@ -1309,6 +1404,11 @@ with chdir(args.src):
     }, ""))
 
     runRules(rules)
+
+    if args.commit:
+        run(["git","add",".","-u"])
+        run(["git","commit","-m","rules: 8 Cleanup"])
+        rules = []
 
     src = Path(dir_main) / 'overlay' / '.'
     tgt = Path(args.src)

--- a/patch.py
+++ b/patch.py
@@ -494,6 +494,10 @@ dir_main = os.path.dirname(os.path.realpath(__file__))
 with chdir(args.src):
     rules = []
 
+    if args.commit:
+        run(["git","add",".","-u"]) # add changed/deleted files, ignore new
+        run(["git","commit","-m",f"0: Modificaitons before Zedless patches"])
+
     cratesToDelete = []
     for crate in CONFIG.bannedCrates:
         if exists(f"crates/{crate}"):

--- a/patch.py
+++ b/patch.py
@@ -575,7 +575,7 @@ with chdir(args.src):
                         del data["dev-dependencies"][crate]
                 if "features" in data:
                     for feature in data["features"]:
-                        data["features"][feature] = filter(
+                        feat_filtered = list(filter(
                             lambda dep: all(
                                 [
                                     not (dep.startswith(f"{crate}/")
@@ -583,7 +583,9 @@ with chdir(args.src):
                                     for crate in CONFIG.bannedCrates
                                 ],
                             ), data["features"][feature]
-                        )
+                        ))
+                        if feat_filtered != data["features"][feature]:
+                            data["features"][feature] = feat_filtered
                 if data["package"]["name"] == "zed":
                     data["package"]["default-run"] = "zedless"
                     for (i, bin) in enumerate(data["bin"]):

--- a/patch.py
+++ b/patch.py
@@ -491,7 +491,8 @@ args = parser.parse_args()
 import shutil
 import os
 dir_main = os.path.dirname(os.path.realpath(__file__))
-with chdir(args.src):
+zed_src = Path(args.src).absolute()
+with chdir(zed_src):
     rules = []
 
     if args.commit:
@@ -546,7 +547,7 @@ with chdir(args.src):
 
     if len(cratesToDelete) > 0:
         for crate in cratesToDelete:
-            tgt = Path(args.src) / 'crates' / crate
+            tgt = zed_src / 'crates' / crate
             print(f"del crate: {crate}\t@ {tgt}")
             shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
         if args.commit:
@@ -601,7 +602,7 @@ with chdir(args.src):
             rules = []
 
     for (crate, mod) in CONFIG.bannedModules:
-        tgt_src = Path(args.src) / 'crates' / crate / 'src'
+        tgt_src = zed_src / 'crates' / crate / 'src'
         print("del mod:", crate, mod, f"\t@ {tgt_src}")
         rules.extend(deletePatterns(f"crates/{crate}/", "rust", [
             f"mod {mod};",
@@ -677,7 +678,7 @@ with chdir(args.src):
                 }
             }
         }))
-        tgt_src = Path(args.src) / 'crates' / crate / 'src'
+        tgt_src = zed_src / 'crates' / crate / 'src'
         tgt_mod =  [    tgt_src    /   f"{mod}.rs"]
         tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
         for tgt in tgt_mod:
@@ -698,7 +699,7 @@ with chdir(args.src):
         rules = []
 
     for provider in CONFIG.bannedLanguageModelProviders:
-        tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
+        tgt_src = zed_src / 'crates' / 'language_models' / 'src' / 'provider'
         tgt = tgt_src / f"{provider.module}.rs"
         print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
         shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
@@ -1399,7 +1400,7 @@ with chdir(args.src):
         rules = []
 
     src = Path(dir_main) / 'overlay' / '.'
-    tgt = Path(args.src)
+    tgt = zed_src
     if args.verbose:
         print(f"  {src}\n →{tgt}")
     shutil.copytree(src,tgt,dirs_exist_ok=True)

--- a/patch.py
+++ b/patch.py
@@ -578,7 +578,8 @@ with chdir(args.src):
                         data["features"][feature] = filter(
                             lambda dep: all(
                                 [
-                                    not dep.startswith(f"{crate}/")
+                                    not (dep.startswith(f"{crate}/")
+                                    or   dep     == f"dep:{crate}"  )
                                     for crate in CONFIG.bannedCrates
                                 ],
                             ), data["features"][feature]

--- a/patch.py
+++ b/patch.py
@@ -1179,7 +1179,7 @@ with chdir(zed_src):
         if args.commit and args.verbose:
             runRules(rules)
             run(["git","add",".","-u"])
-            run(["git","commit","-m",f"rules: 4.3 Remove per Directory items @{target}"])
+            run(["git","commit","-m",f"rules: 4.3 Remove per Directory items @ {target}"])
             rules = []
     if args.commit and not args.verbose:
         runRules(rules)

--- a/patch.py
+++ b/patch.py
@@ -12,6 +12,13 @@ import toml
 import match
 import match.rust
 
+import argparse
+parser = argparse.ArgumentParser(
+    prog       ='Zedless Patch',
+    description='Patches Zed with focus on privacy and being local-first',
+    epilog     ='')
+parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
+
 @contextmanager
 def editTomlDocument(file):
     def callback(v):
@@ -467,8 +474,8 @@ def nullifyIfStatement(target, conditionPattern: str | list[str], selectElse=Tru
             for pattern in conditionPattern
         ])
 
-
-with chdir("source"):
+args = parser.parse_args()
+with chdir(args.src):
     rules = []
 
     cratesToDelete = []

--- a/patch.py
+++ b/patch.py
@@ -474,7 +474,9 @@ def nullifyIfStatement(target, conditionPattern: str | list[str], selectElse=Tru
             for pattern in conditionPattern
         ])
 
+from pathlib      import Path
 args = parser.parse_args()
+import shutil
 with chdir(args.src):
     rules = []
 
@@ -526,8 +528,9 @@ with chdir(args.src):
 
     if len(cratesToDelete) > 0:
         for crate in cratesToDelete:
-            print("delete crate:", crate)
-            run(["rm", "-rf", f"crates/{crate}/"])
+            tgt = Path(args.src) / 'crates' / crate
+            print(f"del crate: {crate}\t@ {tgt}")
+            shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
 
         with editTomlDocument("Cargo.toml") as (data, write):
             data["workspace"]["members"] = list(filter(
@@ -567,7 +570,8 @@ with chdir(args.src):
                 write(data)
 
     for (crate, mod) in CONFIG.bannedModules:
-        print("delete module:", crate, mod)
+        tgt_src = Path(args.src) / 'crates' / crate / 'src'
+        print("del mod:", crate, mod, f"\t@ {tgt_src}")
         rules.extend(deletePatterns(f"crates/{crate}/", "rust", [
             f"mod {mod};",
             f"pub mod {mod};",
@@ -642,11 +646,17 @@ with chdir(args.src):
                 }
             }
         }))
-        run(["rm", "-f", f"crates/{crate}/src/{mod}.rs"] + glob(f"crates/{crate}/src/*/{mod}.rs"))
+        tgt_src = Path(args.src) / 'crates' / crate / 'src'
+        tgt_mod =  [    tgt_src    /   f"{mod}.rs"]
+        tgt_mod += list(tgt_src.glob(f"*/{mod}.rs"))
+        for tgt in tgt_mod:
+            shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
 
     for provider in CONFIG.bannedLanguageModelProviders:
-        print("delete language model provider:", provider.structPrefix)
-        run(["rm", "-f", f"crates/language_models/src/provider/{provider.module}.rs"])
+        tgt_src = Path(args.src) / 'crates' / 'language_models' / 'src' / 'provider'
+        tgt = tgt_src / f"{provider.module}.rs"
+        print(f"del language model provider: {provider.structPrefix} \t@ {tgt}")
+        shutil.rmtree(tgt, ignore_errors=True) #onexc=remove_readonly
         rules.extend(deletePatterns("crates/language_models/", "rust", [
             f"pub mod {provider.module};",
             f"use crate::provider::{provider.module}::$_;",

--- a/patch.py
+++ b/patch.py
@@ -18,6 +18,7 @@ parser = argparse.ArgumentParser(
     description='Patches Zed with focus on privacy and being local-first',
     epilog     ='')
 parser.add_argument('-s','--src',type=str,default="source",help="Path of the Zed's source code")
+parser.add_argument('-v','--verbose',action='store_true',help="Print more info when running")
 
 @contextmanager
 def editTomlDocument(file):

--- a/patch.py
+++ b/patch.py
@@ -520,7 +520,7 @@ with chdir(zed_src):
                 }
             }
         }))
-    cratesToDelete = set(cratesToDelete) # for faster 'in set' matches
+    cratesToRemove = set(CONFIG.bannedCrates) # External imports also need to be removed from the manifest, so don't just include banned crates that are removed locally
 
     crateIdentifiers = [{ "pattern": crate } for crate in CONFIG.bannedCrates]
     rules.extend(mkRule("crates/", "rust", {
@@ -555,14 +555,15 @@ with chdir(zed_src):
             run(["git","add",".","-u"]) # add changed/deleted files, ignore new
             run(["git","commit","-m","✗ 1.2 Deleted Crates"])
 
+    if len(cratesToRemove) > 0:
         with editTomlDocument("Cargo.toml") as (data, write):
             arr = data["workspace"]["members"]
             for i in range(len(arr)):
                 j = len(arr) - i - 1
-                if arr[j].removeprefix("crates/") in cratesToDelete:
+                if arr[j].removeprefix("crates/") in cratesToRemove:
                     del arr[j]
             data["workspace"]["members"] = arr
-            for crate in cratesToDelete:
+            for crate in cratesToRemove:
                 if crate in data["workspace"]["dependencies"]:
                     del data["workspace"]["dependencies"][crate]
                 for prof in data["profile"]:
@@ -572,7 +573,7 @@ with chdir(zed_src):
 
         for manifest in glob("crates/*/Cargo.toml"):
             with editTomlDocument(manifest) as (data, write):
-                for crate in cratesToDelete:
+                for crate in cratesToRemove:
                     if "dependencies" in data and crate in data["dependencies"]:
                         del data["dependencies"][crate]
                     if "dev-dependencies" in data and crate in data["dev-dependencies"]:
@@ -584,7 +585,7 @@ with chdir(zed_src):
                                 [
                                     not (dep.startswith(f"{crate}/")
                                     or   dep     == f"dep:{crate}"  )
-                                    for crate in CONFIG.bannedCrates
+                                    for crate in cratesToRemove
                                 ],
                             ), data["features"][feature]
                         ))


### PR DESCRIPTION
Currently only locally found bannedCrates were removed, so external dependencies couldn't be pruned.
Now external and local crates are combined and removed together when parsing manifests

(stacked on top of the [latest combined PR ](https://github.com/zedless-editor/zedless/pull/20) for ease of diffs)